### PR TITLE
5 feat 방 닫힘 기능 구현

### DIFF
--- a/src/app/api/rooms/[room_id]/route.ts
+++ b/src/app/api/rooms/[room_id]/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma"; // 싱글톤 패턴으로 prisma 클라이언트 가져오기
+
+export const dynamic = "force-dynamic"; // Turbopack 경고 제거
+
+export async function DELETE(
+  req: NextRequest,
+  context: { params: { room_id: string } }
+) {
+  try {
+    // params 전체를 먼저 await 처리
+    const params = await context.params;
+    const roomId = Number(params.room_id);
+
+    if (isNaN(roomId)) {
+      return NextResponse.json(
+        { message: "유효하지 않은 방 ID입니다" },
+        { status: 400 }
+      );
+    }
+
+    const room = await prisma.room.findUnique({ where: { id: roomId } });
+
+    if (!room) {
+      return NextResponse.json(
+        { message: "해당 방을 찾을 수 없습니다" },
+        { status: 404 }
+      );
+    }
+
+    if (room.is_closed) {
+      return NextResponse.json(
+        { message: "이미 닫힌 방입니다" },
+        { status: 400 }
+      );
+    }
+
+    await prisma.room.update({
+      where: { id: roomId },
+      data: { is_closed: true },
+    });
+
+    return NextResponse.json(
+      { message: "방이 성공적으로 닫혔습니다" },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("방 닫기 실패:", error);
+    return NextResponse.json(
+      {
+        message: "서버 오류가 발생했습니다",
+        error: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,8 @@
+// lib/prisma.ts
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient };
+
+export const prisma = globalForPrisma.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/src/pages/api/rooms.ts
+++ b/src/pages/api/rooms.ts
@@ -36,7 +36,7 @@ const parseForm = (
   });
 };
 
-// ✅ 꼭 있어야 함!
+// 꼭 있어야 함!
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
@@ -60,6 +60,8 @@ export default async function handler(
       return res.status(400).json({ message: "파일은 필수입니다." });
 
     const fileBuffer = fs.readFileSync(uploadedFile.filepath);
+    fs.unlinkSync(uploadedFile.filepath); // 임시 파일 삭제
+
     const code = await generateRoomCode();
 
     const now = new Date().toLocaleString("sv-SE", {
@@ -72,7 +74,7 @@ export default async function handler(
         code,
         is_closed: false,
         file: fileBuffer,
-        created_at: now, // ✅ 문자열 그대로 넣기
+        created_at: now, // 문자열 그대로 넣기
       },
     });
 

--- a/src/pages/api/rooms.ts
+++ b/src/pages/api/rooms.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/lib/prisma"; // 싱글톤 패턴 적용
 import formidable, { Fields, Files } from "formidable";
 import fs from "fs";
 import path from "path";
@@ -9,8 +9,6 @@ export const config = {
     bodyParser: false,
   },
 };
-
-const prisma = new PrismaClient();
 
 const generateRoomCode = async (): Promise<number> => {
   let code: number;


### PR DESCRIPTION
## #️⃣연관된 이슈

#5 

## 📝작업 내용
- DELETE /api/rooms/{room_id} 요청을 받는 함수 구현
- room 테이블에 있는 is_closed 컬럼의 상태 값을 true로 변경
- 이미 is_closed가 true이거나, room_id가 존재하지 않을 경우 에러핸들링
- prisma 싱글톤 적용
- 데이터베이스에 파일을 저장하기 위해 public/uploads 밑에 임시로 저장한 파일을 제거하는 코드 추가

### before
<img width="423" alt="Image" src="https://github.com/user-attachments/assets/f473e284-7c79-4fd9-b76f-724722becfce" />

### Postman 요청
<img width="600" alt="Image" src="https://github.com/user-attachments/assets/5d36ce36-71bc-47f8-a4e5-589482dff6b0" />

### after
<img width="420" alt="Image" src="https://github.com/user-attachments/assets/72b3002f-9ea7-447b-8bc7-667f8c141144" />
