### PR TITLE
12 feat 쿠키 생성 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,9 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-/public/uploads
+/public/uploads/*
+!/public/uploads/.gitkeep
+
 *.webm
 *.mp4
 *.wav

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "formidable": "^2.1.1",
         "next": "15.3.2",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -7193,6 +7194,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "formidable": "^2.1.1",
     "next": "15.3.2",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/prisma/migrations/20250515214116_update_question_model/migration.sql
+++ b/prisma/migrations/20250515214116_update_question_model/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `visitorId` on the `question` table. All the data in the column will be lost.
+  - Added the required column `created_at` to the `Question` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `creator_id` to the `Question` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `question` DROP COLUMN `visitorId`,
+    ADD COLUMN `created_at` VARCHAR(25) NOT NULL,
+    ADD COLUMN `creator_id` VARCHAR(36) NOT NULL,
+    ADD COLUMN `is_selected` BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN `likes` BIGINT NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,9 @@ model Question {
   question_id BigInt   @id @default(autoincrement())
   room        Room     @relation(fields: [room_id], references: [id], onDelete: Cascade)
   room_id     BigInt
+  creator_id  String   @db.VarChar(36)
+  created_at  String   @db.VarChar(25) // ✅ 여기 DateTime → String 으로 수정
   text        String   @db.Text
-  visitorId   String   @db.VarChar(100)
+  likes       BigInt   @default(0)
+  is_selected Boolean  @default(false)
 }

--- a/src/app/api/visitor/route.ts
+++ b/src/app/api/visitor/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { v4 as uuidv4 } from 'uuid';
+  
+
+export async function GET(req: NextRequest) {
+  const visitorCookie = await cookies();
+  const visitorId = visitorCookie.get('visitor_id')?.value; // 기존 쿠키 있는지 확인
+
+  // 기존 Visitor ID 쿠키가 없으면 새로 생성
+  if (!visitorId) {
+    const newVisitorId = uuidv4();
+
+    // Visitor ID 쿠키 설정 (session 쿠키로 만료일 설정 X)
+    visitorCookie.set('visitor_id', newVisitorId, {
+      httpOnly: true, // 클라이언트에서 접근 불가 (보안)
+      secure: process.env.NODE_ENV === 'production', // HTTPS 에서만 전송
+    //   maxAge: 60 * 60 * 24 * 365, // 예: 1년 유효
+      path: '/', // 모든 경로에서 쿠키 사용
+      sameSite: 'lax', // CSRF 방지
+    });
+
+    // console.log('새로운 Visitor');
+    return NextResponse.json(
+        { message: 'New Visitor'},
+        { status: 201 } 
+    );
+  } else {
+    // console.log('기존 Visitor');
+    return NextResponse.json(
+        { message: 'Existing Visitor'},
+        { status: 200 }
+    );
+  }
+}
+
+
+
+

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+// ✨ Next.js 미들웨어 함수 - CORS 헤더 직접 설정 ✨
+export async function middleware(req: NextRequest) {
+    // NextResponse.next()를 사용하여 다음 미들웨어 또는 라우트 핸들러로 응답 객체 전달
+    const res = NextResponse.next();
+    
+    // ✨ 응답 헤더에 CORS 관련 정보 추가 ✨
+    // '*' 대신 허용할 특정 출처를 설정하는 것이 보안상 더 좋음.
+    // 여러 출처를 허용해야 한다면 req.headers.get('Origin') 값을 확인해서 동적으로 설정.
+    const origin = req.headers.get('Origin') || ''; // 요청 Origin 가져오기
+    const allowedOrigins = ['http://localhost:5173']; // ✨ 허용할 출처 목록 ✨
+    
+    if (allowedOrigins.includes(origin)) {
+        res.headers.set('Access-Control-Allow-Origin', origin);
+    } else {
+        // 허용되지 않은 출처의 경우, CORS 헤더를 설정하지 않거나 기본값으로 둡니다.
+        // 브라우저는 Access-Control-Allow-Origin 헤더가 없거나 일치하지 않으면 CORS 에러를 발생시킵니다.
+        // res.headers.set('Access-Control-Allow-Origin', 'null'); // 또는 다른 기본값 설정
+    }
+    
+    
+    // 허용할 메서드 설정 (실제 API 라우트에서 사용하는 메서드들 포함)
+    res.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+    // 허용할 요청 헤더 설정 (프론트엔드에서 보낼 수 있는 헤더들 포함)
+    res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
+    // 자격 증명 (쿠키 등) 포함 요청 허용
+    res.headers.set('Access-Control-Allow-Credentials', 'true'); // ✨ 'true'는 문자열이어야 함 ✨
+    // Preflight 응답을 브라우저가 캐시할 시간 (초)
+    res.headers.set('Access-Control-Max-Age', '86400'); // 예: 24시간
+    
+    
+    // OPTIONS 요청 (Preflight)에 대한 특별 처리
+    // middleware.ts에서 OPTIONS 요청을 처리하고 싶다면 여기서 바로 응답을 반환.
+    // 이 경우 route.ts 파일에는 OPTIONS 핸들러를 만들 필요가 없음.
+    if (req.method === 'OPTIONS') {
+        // OPTIONS 요청에 필요한 CORS 헤더들은 위에서 이미 추가되었으므로,
+        // 성공 상태 코드 200 (또는 204)와 함께 헤더만 설정된 응답을 바로 반환.
+        return NextResponse.json({}, { status: 200, headers: res.headers });
+     // 여기서 반환하면 다음 미들웨어 체인이나 라우트 핸들러(route.ts 파일의 OPTIONS 함수)는 실행되지 않음.
+  }
+
+  // OPTIONS 요청이 아니면, 수정된 응답 객체를 다음 미들웨어 체인 또는 라우트 핸들러로 전달.
+  return res;
+}
+
+// ✨ 미들웨어를 적용할 경로 설정 (API 라우트만 대상으로) ✨
+export const config = {
+  matcher: '/api/:path*', // /api/ 로 시작하는 모든 경로에 미들웨어 적용
+};
+


### PR DESCRIPTION
## #️⃣연관된 이슈

> #12 

## 📝작업 내용

- [x] public/uploads/.gitkeep 파일 추가해서 디렉토리가 git에 유지되도록 수정했습니다.

- [x] question 모델에 visitor_id를 creator_id로 수정하고 좋아요, 하이라이트 속성 추가했습니다.

- [x] 루트 디렉토리에 middleware.ts 작성해 api/의 모든 route.ts에 CORS 설정 적용했습니다.

- [x] 웹페이지에 처음 접속할 때 사용자를 식별하는 visitor_id를 생성하고 브라우저에 쿠키로 저장하는 기능 구현했습니다.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

처음 웹페이지 접속시 쿠키가 생성됩니다. Status: 201 Created
![image](https://github.com/user-attachments/assets/d13da90d-aef6-44fa-8430-61d181695a67)

브라우저에 쿠키를 저장하고 API 통신시 사용할 예정입니다.
![image](https://github.com/user-attachments/assets/cf2a30eb-e8bd-4160-83a3-e33cd2de7730)


새로고침이나 다른 페이지 이동시 기존 쿠키를 사용합니다. Status: 200 OK
모든 브라우저를 닫으면 쿠키가 사라지고 다음 접속시 새로 생성됩니다.
![image](https://github.com/user-attachments/assets/e860b282-bf00-4998-95e4-5d6e180bb2bd)


## 💬리뷰 요구사항(선택)

