### PR TITLE
fix: 방 입장시 visitor_id 포함해서 응답 반환

### DIFF
--- a/src/pages/api/rooms.ts
+++ b/src/pages/api/rooms.ts
@@ -71,6 +71,7 @@ export default async function handler(
         file_name: true,
         file_type: true,
         creator_id: true,
+        is_closed: true,
       },
     });
 
@@ -84,6 +85,8 @@ export default async function handler(
         file_name: room.file_name,
         file_type: room.file_type,
         creator_id: room.creator_id,
+        is_closed: room.is_closed,
+        visitor_id: visitorId,
       });
     } else {
       return res.status(404).json({


### PR DESCRIPTION
## #️⃣연관된 이슈

> #24 

## 📝작업 내용

방 입장시에 현재 접속자의 visitor_id 를 응답에 포함시켰고
is_closed도 추가했습니다!

### 스크린샷 (선택)

쿠키에 저장된 visitor_id(방에 접속한 사용자)와 같은 visitor_id가 응답값에 있음!
![image](https://github.com/user-attachments/assets/7925bc20-8de3-4d98-a929-096ed16f1f93)



> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

