### PR TITLE
feat: room_id 방의 전체 질문 목록 조회 기능 구현

### DIFF
--- a/src/app/api/rooms/[room_id]/questions/route.ts
+++ b/src/app/api/rooms/[room_id]/questions/route.ts
@@ -85,3 +85,87 @@ export async function POST(
         );
     }
 }
+
+export async function GET(
+    // middleware.ts를 거쳐 전달받은 요청 객체
+    req: NextRequest,
+    // 동적 라우팅 파라미터를 context.params로 넘겨줌
+    // ex) api/questions/1 이면 context.params.room_id 값은 "1"
+    context: {params: {room_id: string}}
+) {
+    // middleware.ts에서 헤더에 visitor-id 값을 설정했으므로 값을 가져와서 확인
+    const visitorId = req.headers.get('visitor-id');
+    if (visitorId === null || visitorId === undefined) {
+        console.error('미들웨어에서 visitorId 헤더가 전달되지 않았습니다');
+        return NextResponse.json(
+            { message: '내부 서버 오류: visitorId 식별 불가'},
+            { status: 500 }
+        );
+    }
+
+    // Next.js 15+ 변경사항으로 context 객체안의 params 속성 접근하기 전에 await 해야함 
+    const awaitedParams = await context.params;
+    const roomId = Number(awaitedParams.room_id);
+    if (isNaN(roomId)) {
+        return NextResponse.json(
+            { message: '숫자로 된 room_id를 입력해주세요'},
+            { status: 400 }
+        );
+    }
+
+    try {
+        const room = await prisma.room.findUnique({ where: {id: roomId} });
+
+        if (!room) {
+            return NextResponse.json(
+                { message: `방 #${roomId} 을 찾을 수 없습니다.`},
+                { status: 404 }
+            );
+        }
+
+        // [room_id]로 받아온 roomId를 id로 갖고있는 room과 
+        // include 옵션으로 가져온 관계 데이터(관계 필드이름:questions)를 가져옴
+        const allQuestionsInThisRoom = await prisma.room.findUnique({
+            where: { id: roomId },
+            include: { questions: true }
+        });
+
+        if (!allQuestionsInThisRoom) {
+            return NextResponse.json(
+                { message: `방 #${roomId} 에 생성된 질문이 없습니다.`},
+                { status: 404 }
+            );
+        }
+
+        //질문들을 map에 담아서 가져옴
+        const questionsMap = allQuestionsInThisRoom.questions.map(question => ({
+            room_id: question.room_id.toString(),
+            question_id: question.question_id.toString(),
+            creator_id: question.creator_id,
+            created_at: question.created_at,
+            text: question.text,
+            likes: question.likes.toString(),
+            is_selected: question.is_selected,
+        }));
+
+        //편의를 위해 질문 몇개인지 같이 보냄
+        const questionsCount = questionsMap.length;
+
+        const responseBody = {
+            message: `방 #${roomId} 의 전체 질문 목록 조회 성공!`,
+            count: questionsCount.toString(),
+            questions: questionsMap,
+        }
+
+        return NextResponse.json(
+            responseBody,
+            { status: 200 },
+        );
+    } catch (error) {
+        console.error('질문 생성 중 오류:', error);
+        return NextResponse.json(
+            { message: '질문 생성 중 서버 오류 발생' },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/rooms/[room_id]/questions/route.ts
+++ b/src/app/api/rooms/[room_id]/questions/route.ts
@@ -129,27 +129,27 @@ export async function GET(
             where: { id: roomId },
             include: { questions: true }
         });
-
-        if (!allQuestionsInThisRoom) {
-            return NextResponse.json(
-                { message: `방 #${roomId} 에 생성된 질문이 없습니다.`},
-                { status: 404 }
-            );
-        }
-
-        //질문들을 map에 담아서 가져옴
-        const questionsMap = allQuestionsInThisRoom.questions.map(question => ({
-            room_id: question.room_id.toString(),
-            question_id: question.question_id.toString(),
-            creator_id: question.creator_id,
-            created_at: question.created_at,
-            text: question.text,
-            likes: question.likes.toString(),
-            is_selected: question.is_selected,
-        }));
-
-        //편의를 위해 질문 몇개인지 같이 보냄
-        const questionsCount = questionsMap.length;
+    
+    //질문들을 map에 담아서 가져옴
+    const questionsMap = allQuestionsInThisRoom.questions.map(question => ({
+        room_id: question.room_id.toString(),
+        question_id: question.question_id.toString(),
+        creator_id: question.creator_id,
+        created_at: question.created_at,
+        text: question.text,
+        likes: question.likes.toString(),
+        is_selected: question.is_selected,
+    }));
+    
+    //편의를 위해 질문 몇개인지 같이 보냄
+    const questionsCount = questionsMap.length;
+    //질문이 0개면 404 return
+    if (!questionsCount) {
+        return NextResponse.json(
+            { message: `방 #${roomId} 에 생성된 질문이 없습니다.`},
+            { status: 404 }
+        );
+    }
 
         const responseBody = {
             message: `방 #${roomId} 의 전체 질문 목록 조회 성공!`,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #27 

## 📝작업 내용

> room_id 방의 전체 질문을 조회해 응답을 반환하는 기능을 구현했습니다.

### 스크린샷 (선택)

room_id: 4에 5개의 질문이 생성된 상태
![image](https://github.com/user-attachments/assets/98fe4248-a1d1-43b8-9275-1c0e41b2a1ee)

없는 room_id -  GET (http://localhost:3000/api/rooms/1/questions)
![image](https://github.com/user-attachments/assets/b926d628-8cdc-4862-ae86-e2e241dafd72)

질문 성공적으로 조회 - GET (http://localhost:3000/api/rooms/4/questions)
![image](https://github.com/user-attachments/assets/e014b726-b1be-4bc4-87db-1632f649984c)

room_id 방에 생성된 질문이 없을 때
![image](https://github.com/user-attachments/assets/83f0ad1e-0988-49be-b42d-cc05f08b6437)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
