### PR TITLE
29 feat 질문 답변 완료 api 기능 구현

### DIFF
--- a/prisma/migrations/20250520083446_update_is_answered_to_question/migration.sql
+++ b/prisma/migrations/20250520083446_update_is_answered_to_question/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `is_selected` on the `question` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE `question` DROP COLUMN `is_selected`,
+    ADD COLUMN `is_answered` BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,5 +29,5 @@ model Question {
   created_at  String   @db.VarChar(25) // ✅ 여기 DateTime → String 으로 수정
   text        String   @db.Text
   likes       BigInt   @default(0)
-  is_selected Boolean  @default(false)
+  is_answered Boolean  @default(false)
 }

--- a/src/app/api/rooms/[room_id]/questions/[question_id]/route.ts
+++ b/src/app/api/rooms/[room_id]/questions/[question_id]/route.ts
@@ -94,7 +94,7 @@ export async function PATCH(
             created_at: updatedQuestion.created_at,
             text: updatedQuestion.text,
             likes: updatedQuestion.likes.toString(),
-            is_selected: updatedQuestion.is_selected
+            is_answered: updatedQuestion.is_answered
         }
 
         return NextResponse.json(
@@ -188,7 +188,7 @@ export async function DELETE(
             created_at: deletedQuestion.created_at,
             text: deletedQuestion.text,
             likes: deletedQuestion.likes.toString(),
-            is_selected: deletedQuestion.is_selected,
+            is_answered: deletedQuestion.is_answered,
         }
 
         return NextResponse.json(

--- a/src/app/api/rooms/[room_id]/questions/[question_id]/status/route.ts
+++ b/src/app/api/rooms/[room_id]/questions/[question_id]/status/route.ts
@@ -1,0 +1,106 @@
+// src/api/rooms/[room_id]/questions/[question_id]/status/route.ts : 
+// [room_id] 방의 [question_id]질문 is_answered 상태 변경 (PATCH)
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma'; // 싱글톤 패턴 적용
+
+export async function PATCH(
+    // middleware.ts를 거쳐 전달받은 요청 객체
+    req: NextRequest,
+    // 동적 라우팅 파라미터를 context.params로 넘겨줌
+    // ex) /api/rooms/1/questions/11 이면
+    // context.params.room_id : "1", context.params.question_id : "11"
+    context: {params: { room_id: string, question_id: string}}
+) {
+    // middleware.ts에서 헤더에 visitor-id 값을 설정했으므로 값을 가져와서 확인
+    const visitorId = req.headers.get('visitor-id');
+    if (visitorId === null || visitorId === undefined) {
+        console.error('미들웨어에서 visitorId 헤더가 전달되지 않았습니다');
+        return NextResponse.json(
+            { message: '내부 서버 오류: visitorId 식별 불가'},
+            { status: 500 }
+        );
+    }
+
+    // Next.js 15+ 변경사항으로 context 객체안의 params 속성 접근하기 전에 await 해야함 
+    const awaitedParams = await context.params;
+    const roomId = Number(awaitedParams.room_id);
+    if (isNaN(roomId)) {
+        return NextResponse.json(
+            { message: '숫자로 된 room_id를 입력해주세요' },
+            { status: 400 }
+        )
+    };
+
+    const questionId = Number(awaitedParams.question_id);
+    if (isNaN(questionId)) {
+        return NextResponse.json(
+            { message: '숫자로 된 question_id를 입력해주세요' },
+            { status: 400 }
+        );
+    }
+
+    try {
+        const room = await prisma.room.findUnique({ where: {id: roomId} });
+        if (!room) {
+            return NextResponse.json(
+                { message: `방 #${roomId} 을 찾을 수 없습니다.`},
+                { status: 404 }
+            );
+        }
+        
+        const question = await prisma.question.findUnique({
+            where: {
+                room_id: roomId,
+                question_id: questionId,
+            },
+        });
+        if (!question) {
+            return NextResponse.json(
+                { message: `방 #${roomId} 에서 질문 #${questionId} 을 찾을 수 없습니다.`},
+                { status: 404 }
+            );
+        }
+
+        if (room.creator_id !== visitorId) {
+            return NextResponse.json(
+                { message: '권한이 없습니다!' },
+                { status: 403 }
+            );
+        }
+
+        if (question.is_answered === true) {
+            return NextResponse.json(
+                { message: '이미 완료된 답변입니다!' },
+                { status: 400 }
+            );
+        }
+
+        const updatedQuestion = await prisma.question.update({
+            where: { question_id: questionId },
+            data: { is_answered: true },
+        });
+
+        const responseBody = {
+            message: '질문에 대한 답변이 완료됨!',
+            room_id: updatedQuestion.room_id.toString(),
+            question_id: updatedQuestion.question_id.toString(),
+            creator_id: updatedQuestion.creator_id,
+            created_at: updatedQuestion.created_at,
+            text: updatedQuestion.text,
+            likes: updatedQuestion.likes.toString(),
+            is_answered: updatedQuestion.is_answered
+        }
+
+        return NextResponse.json(
+            responseBody,
+            { status: 200 },
+        );
+    } catch (error) {
+        console.error('질문 수정 중 오류:', error);
+        return NextResponse.json(
+            { message: '질문 생성 중 서버 오류 발생' },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/rooms/[room_id]/questions/route.ts
+++ b/src/app/api/rooms/[room_id]/questions/route.ts
@@ -124,10 +124,15 @@ export async function GET(
         }
 
         // [room_id]로 받아온 roomId를 id로 갖고있는 room과 
-        // include 옵션으로 가져온 관계 데이터(관계 필드이름:questions)를 가져옴
         const allQuestionsInThisRoom = await prisma.room.findUnique({
             where: { id: roomId },
-            include: { questions: true }
+            // include 옵션으로 가져온 관계 데이터(관계 필드이름:questions)를 가져옴
+            include: { 
+                questions: {
+                    // 이 중에서 is_answered 속성이 false 인 질문들만 가져옴
+                    where: { is_answered: false }
+                }
+            }
         });
 
         if (!allQuestionsInThisRoom) {

--- a/src/app/api/rooms/[room_id]/questions/route.ts
+++ b/src/app/api/rooms/[room_id]/questions/route.ts
@@ -129,27 +129,34 @@ export async function GET(
             where: { id: roomId },
             include: { questions: true }
         });
+
+        if (!allQuestionsInThisRoom) {
+            return NextResponse.json(
+                { message: `방 # ${roomId} 의 질문 목록 조회 실패!`},
+                { status: 400 }
+            );
+        }
     
-    //질문들을 map에 담아서 가져옴
-    const questionsMap = allQuestionsInThisRoom.questions.map(question => ({
-        room_id: question.room_id.toString(),
-        question_id: question.question_id.toString(),
-        creator_id: question.creator_id,
-        created_at: question.created_at,
-        text: question.text,
-        likes: question.likes.toString(),
-        is_answered: question.is_answered,
-    }));
-    
-    //편의를 위해 질문 몇개인지 같이 보냄
-    const questionsCount = questionsMap.length;
-    //질문이 0개면 404 return
-    if (!questionsCount) {
-        return NextResponse.json(
-            { message: `방 #${roomId} 에 생성된 질문이 없습니다.`},
-            { status: 404 }
-        );
-    }
+        //질문들을 map에 담아서 가져옴
+        const questionsMap = allQuestionsInThisRoom.questions.map(question => ({
+            room_id: question.room_id.toString(),
+            question_id: question.question_id.toString(),
+            creator_id: question.creator_id,
+            created_at: question.created_at,
+            text: question.text,
+            likes: question.likes.toString(),
+            is_answered: question.is_answered,
+        }));
+        
+        //편의를 위해 질문 몇개인지 같이 보냄
+        const questionsCount = questionsMap.length;
+        //질문이 0개면 404 return
+        if (!questionsCount) {
+            return NextResponse.json(
+                { message: `방 #${roomId} 에 생성된 질문이 없습니다.`},
+                { status: 404 }
+            );
+        }
 
         const responseBody = {
             message: `방 #${roomId} 의 전체 질문 목록 조회 성공!`,

--- a/src/app/api/rooms/[room_id]/questions/route.ts
+++ b/src/app/api/rooms/[room_id]/questions/route.ts
@@ -70,7 +70,7 @@ export async function POST(
             created_at: newQuestion.created_at,
             text: newQuestion.text,
             likes: newQuestion.likes.toString(),
-            is_selected: newQuestion.is_selected
+            is_answered: newQuestion.is_answered
         }
 
         return NextResponse.json(
@@ -138,7 +138,7 @@ export async function GET(
         created_at: question.created_at,
         text: question.text,
         likes: question.likes.toString(),
-        is_selected: question.is_selected,
+        is_answered: question.is_answered,
     }));
     
     //편의를 위해 질문 몇개인지 같이 보냄


### PR DESCRIPTION
## #️⃣연관된 이슈

> #29 #28 

## 📝작업 내용

질문에 대한 답변 완료 시 question 의 is_answered 속성을 false 에서 true 로 바꾸는 API 기능을 추가했습니다.
엔드포인트는 api/rooms/{room_id}/questions/{question_id}/status 입니다.

기존에 is_selected 로 작성된 코드를 is_answered로 모두 수정했습니다.

질문 전체 조회 시 is_answered가 true라면 응답에서 제외하도록 수정했습니다.

schema.prisma가 변경되어 npx prisma migrate dev로 기존 db 초기화 해야합니다.

### 스크린샷 (선택)

room_id: 1 에 question 5개 있는 상태
![image](https://github.com/user-attachments/assets/a52c5812-7ae0-44ff-9ca4-3ffd05d972ef)

방 생성자 (room.creator_id) 가 아니라면 답변 완료 권한 없음
![image](https://github.com/user-attachments/assets/f0340953-4345-4811-a126-1d97dab8e340)

방 생성자라면 (room.creator_id === visitor_id) 답변 완료 가능
![image](https://github.com/user-attachments/assets/d5a5c8c4-8ff7-4077-9bc3-07d9a812f731)

이미 답변완료 처리된 질문이라면
![image](https://github.com/user-attachments/assets/e3f8a392-bf0c-4adf-a54d-c9892da1a656)


----------------------------------모든 질문 조회 TEST---------------------------------

1~3 질문들은 답변 완료
![image](https://github.com/user-attachments/assets/85dc41a0-985a-4caf-b687-6902b3fce585)

답변완료 처리되지 않은 질문들만 조회됨
![image](https://github.com/user-attachments/assets/ac2f835c-b973-4ca4-8628-1b2c48dbb8f0)




## 💬리뷰 요구사항(선택)
