### PR TITLE
feat: 관리자 시점 모든 방/질문 조회 API 기능 구현

### DIFF
--- a/src/app/api/admin/rooms/[room_id]/route.ts
+++ b/src/app/api/admin/rooms/[room_id]/route.ts
@@ -68,13 +68,6 @@ export async function GET(
         
         //편의를 위해 질문 몇개인지 같이 보냄
         const questionsCount = questionsMap.length;
-        //질문이 0개면 404 return
-        if (!questionsCount) {
-            return NextResponse.json(
-                { message: `방 #${roomId} 에 생성된 질문이 없습니다.`},
-                { status: 404 }
-            );
-        }
 
         const responseBody = {
             message: `방 #${roomId} 의 전체 질문 목록 조회 성공!`,

--- a/src/app/api/admin/rooms/[room_id]/route.ts
+++ b/src/app/api/admin/rooms/[room_id]/route.ts
@@ -1,0 +1,96 @@
+// src/app/api/admin/rooms/[room_id]/route.ts
+// 관리자 시점 room_id 방의 전체 질문(답변완료 포함) 조회 (GET)
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma'; // 싱글톤 패턴 적용
+
+export async function GET(
+    // middleware.ts를 거쳐 전달받은 요청 객체
+    req: NextRequest,
+    // 동적 라우팅 파라미터를 context.params로 넘겨줌
+    // ex) api/questions/1 이면 context.params.room_id 값은 "1"
+    context: {params: {room_id: string}}
+) {
+    // middleware.ts에서 헤더에 visitor-id 값을 설정했으므로 값을 가져와서 확인
+    const visitorId = req.headers.get('visitor-id');
+    if (visitorId === null || visitorId === undefined) {
+        console.error('미들웨어에서 visitorId 헤더가 전달되지 않았습니다');
+        return NextResponse.json(
+            { message: '내부 서버 오류: visitorId 식별 불가'},
+            { status: 500 }
+        );
+    }
+
+    // Next.js 15+ 변경사항으로 context 객체안의 params 속성 접근하기 전에 await 해야함 
+    const awaitedParams = await context.params;
+    const roomId = Number(awaitedParams.room_id);
+    if (isNaN(roomId)) {
+        return NextResponse.json(
+            { message: '숫자로 된 room_id를 입력해주세요'},
+            { status: 400 }
+        );
+    }
+
+    try {
+        const room = await prisma.room.findUnique({ where: {id: roomId} });
+
+        if (!room) {
+            return NextResponse.json(
+                { message: `방 #${roomId} 을 찾을 수 없습니다.`},
+                { status: 404 }
+            );
+        }
+
+        // [room_id]로 받아온 roomId를 id로 갖고있는 room과 
+        const allQuestionsInThisRoom = await prisma.room.findUnique({
+            where: { id: roomId },
+            // include 옵션으로 가져온 관계 데이터(관계 필드이름:questions)를 가져옴
+            include: { questions: true }
+        });
+
+        if (!allQuestionsInThisRoom) {
+            return NextResponse.json(
+                { message: `방 # ${roomId} 의 질문 목록 조회 실패!`},
+                { status: 400 }
+            );
+        }
+    
+        //질문들을 map에 담아서 가져옴
+        const questionsMap = allQuestionsInThisRoom.questions.map(question => ({
+            room_id: question.room_id.toString(),
+            question_id: question.question_id.toString(),
+            creator_id: question.creator_id,
+            created_at: question.created_at,
+            text: question.text,
+            likes: question.likes.toString(),
+            is_answered: question.is_answered,
+        }));
+        
+        //편의를 위해 질문 몇개인지 같이 보냄
+        const questionsCount = questionsMap.length;
+        //질문이 0개면 404 return
+        if (!questionsCount) {
+            return NextResponse.json(
+                { message: `방 #${roomId} 에 생성된 질문이 없습니다.`},
+                { status: 404 }
+            );
+        }
+
+        const responseBody = {
+            message: `방 #${roomId} 의 전체 질문 목록 조회 성공!`,
+            count: questionsCount.toString(),
+            questions: questionsMap,
+        }
+
+        return NextResponse.json(
+            responseBody,
+            { status: 200 },
+        );
+    } catch (error) {
+        console.error('질문 생성 중 오류:', error);
+        return NextResponse.json(
+            { message: '질문 생성 중 서버 오류 발생' },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/admin/rooms/route.ts
+++ b/src/app/api/admin/rooms/route.ts
@@ -1,0 +1,52 @@
+// src/app/api/admin/rooms/route.ts
+// 관리자 시점 전체 rooms 목록 조회 (GET)
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma'; // 싱글톤 패턴 적용
+
+export async function GET(
+    // middleware.ts를 거쳐 전달받은 요청 객체
+    req: NextRequest
+) {
+    // middleware.ts에서 헤더에 visitor-id 값을 설정했으므로 값을 가져와서 확인
+    const visitorId = req.headers.get('visitor-id');
+    if (visitorId === null || visitorId === undefined) {
+        console.error('미들웨어에서 visitorId 헤더가 전달되지 않았습니다');
+        return NextResponse.json(
+            { message: '내부 서버 오류: visitorId 식별 불가'},
+            { status: 500 }
+        );
+    }
+
+    try {
+        //allRooms : Room 객체들의 배열이 반환됨
+        const allRooms = await prisma.room.findMany({
+            orderBy: { created_at: 'asc' }
+        })
+    
+        //질문들을 map에 담아서 가져옴
+        const roomsMap = allRooms.map(room => ({
+            room_id: room.id.toString(),
+            title: room.title,
+            code: room.code.toString(),
+            created_at: room.created_at,
+        }));
+        
+        const responseBody = {
+            message: '모든 방 목록 조회 성공!',
+            count: roomsMap.length.toString(),
+            rooms: roomsMap,
+        }
+
+        return NextResponse.json(
+            responseBody,
+            { status: 200 },
+        );
+    } catch (error) {
+        console.error('질문 생성 중 오류:', error);
+        return NextResponse.json(
+            { message: '질문 생성 중 서버 오류 발생' },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/rooms/[room_id]/questions/route.ts
+++ b/src/app/api/rooms/[room_id]/questions/route.ts
@@ -155,13 +155,6 @@ export async function GET(
         
         //편의를 위해 질문 몇개인지 같이 보냄
         const questionsCount = questionsMap.length;
-        //질문이 0개면 404 return
-        if (!questionsCount) {
-            return NextResponse.json(
-                { message: `방 #${roomId} 에 생성된 질문이 없습니다.`},
-                { status: 404 }
-            );
-        }
 
         const responseBody = {
             message: `방 #${roomId} 의 전체 질문 목록 조회 성공!`,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #33 

## 📝작업 내용

> 관리자 시점 모든 방과 질문 조회 API 기능을 구현했습니다.

### 스크린샷 (선택)
GET (http://localhost:3000/api/admin/rooms)
생성된 모든 방을 배열에 담아 응답합니다.
![image](https://github.com/user-attachments/assets/000715a4-3829-4af0-b207-f18cb4601d4f)

GET (http://localhost:3000/api/admin/rooms/4)
room_id 방의 모든 질문을 배열에 담아 응답합니다.
답변이 완료된 질문도 모두 포함합니다.
![image](https://github.com/user-attachments/assets/fd81f647-7395-4449-a5f8-26f7ad48d31b)

--------------------------------0522 fix-----------------------------------------------
일반 질문 조회/ 관리자 시점 질문 조회 시  
질문이 없을 때 404를 반환했었는데
두 경우 모두 빈 배열을 담아 반환하도록 수정했습니다!
GET http://localhost:3000/api/admin/rooms/7
![image](https://github.com/user-attachments/assets/528e25ae-1b5a-4e72-8372-159b8ec637cc)


방이 없는 경우에도 rooms에 빈 배열이 담겨 반환됩니다!
GET http://localhost:3000/api/admin/rooms
![image](https://github.com/user-attachments/assets/7148deb1-e514-4983-9a13-7020938e503e)


